### PR TITLE
ARFile_t changes for large files

### DIFF
--- a/acqu_core/AcquRoot/src/ARFile_t.cc
+++ b/acqu_core/AcquRoot/src/ARFile_t.cc
@@ -67,7 +67,6 @@ ARFile_t::ARFile_t( const Char_t* name, Int_t flags, mode_t mode,
   else fName = sys->BuildName( (Char_t*)name );
   switch(i){
   default:
-    flags = O_LARGEFILE;
     fPath = open(fName, flags, mode);
     if(fPath == -1)
       PrintError("<ERROR ARFile_t: file open by open() failed>", EErrFatal);

--- a/acqu_core/AcquRoot/src/ARFile_t.h
+++ b/acqu_core/AcquRoot/src/ARFile_t.h
@@ -26,6 +26,7 @@
 #ifndef _ARFile_t_h_
 #define _ARFile_t_h_
 
+#define _FILE_OFFSET_BITS 64
 #include "TA2System.h"                  // AcquRoot base class
 #include "EnumConst.h"			// integer constant defs
 


### PR DESCRIPTION
A different fix for analyzing files larger than 2GB on 32 bit systems, which should hopefully be compatible with running the DAQ online
