### PR TITLE
Bug fix

### DIFF
--- a/acqu_user/root/src/TA2GoAT.cc
+++ b/acqu_user/root/src/TA2GoAT.cc
@@ -492,11 +492,6 @@ void    TA2GoAT::PostInit()
     }
 
 
-  // Recording start time of file
-
-  Int_t timestamp = gAR->GetFileTimeEpoch();
-  treeSetupParameters->Branch("TimeStamp", &timestamp, "TimeStamp/I");
-
   // Adding Tagger information to parameters tree
 
   Int_t nTagger;
@@ -547,6 +542,10 @@ void    TA2GoAT::PostInit()
   // Store Scalers for non-MC process
   if (gAR->GetProcessType() != EMCProcess) 
     {
+      // Recording start time of file
+      Int_t timestamp = gAR->GetFileTimeEpoch();
+      treeSetupParameters->Branch("TimeStamp", &timestamp, "TimeStamp/I");
+      //
       treeScalers = new TTree("scalers", "scalers");
       treeScalers->Branch("eventNumber", &eventNumber, "eventNumber/I");
       treeScalers->Branch("eventID", &eventID, "eventID/I");


### PR DESCRIPTION
Hi @ppmartel and @werthm,

inside the TA2GoAT class, I moved the timestamp info in the check for non-MC input files, because it was crashing while searching for the timestamp in the MC.
I checked, and now it complies and it works.

Ciao,
Edoardo