### PR TITLE
Small change to FinishBatch macro for ROOT6 compatibility.

### DIFF
--- a/acqu_user/root/macros/FinishBatch.C
+++ b/acqu_user/root/macros/FinishBatch.C
@@ -20,7 +20,7 @@ void FinishBatch(TString sInput="", TString sOutput="ARHist"){
   
   // Save histograms to file and close it
   TFile f(sFile, "recreate");
-  if( !f ){
+  if( !f.IsOpen() ){
     printf("Open file %s for histogram save FAILED!!\n",sFile.Data());
     return;
   }


### PR DESCRIPTION
Hi,

I did a small change in the FinishBatch.C macro to make it running with ROOT6. I saw that Phil already did similar changes to FinishMacro but, for some reason, I normally use the other one.

